### PR TITLE
fix: use typing_extensions for older python version

### DIFF
--- a/gerd/models/model.py
+++ b/gerd/models/model.py
@@ -1,7 +1,13 @@
 import os
+import sys
 from pathlib import Path
 from string import Formatter
-from typing import Any, List, Literal, Mapping, Optional, Tuple, TypedDict
+from typing import Any, List, Literal, Mapping, Optional, Tuple
+
+if sys.version_info < (3, 12):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 from jinja2 import Environment, FileSystemLoader, Template, meta, select_autoescape
 from pydantic import (


### PR DESCRIPTION
Running the lora example on python < 3.12 runs into the issue "pydantic.errors.PydanticUserError: Please use typing_extensions.TypedDict instead of typing.TypedDict on Python < 3.12.". Thats what this pr does. 
See also this issue at [pydantic](https://github.com/pydantic/pydantic/issues/6645)
