### PR TITLE
fix: Issues with settings in frontend

### DIFF
--- a/gerd/frontends/generate.py
+++ b/gerd/frontends/generate.py
@@ -136,7 +136,7 @@ with demo:
             LoraTrainingConfig.model_validate(
                 json.loads((lora_dir / x / "training_parameters.json").read_text())
             ).model.name
-            if x
+            if x != "None"
             else d
         ),
         inputs=[origin, model_name],

--- a/gerd/frontends/generate.py
+++ b/gerd/frontends/generate.py
@@ -46,7 +46,7 @@ def load_model(model_name: str, origin: str) -> dict[str, Any]:
     """
     if Global.service is not None:
         del Global.service
-    model_config = config.model_copy()
+    model_config = config.model_copy(deep=True)
     model_config.model.name = model_name
     if origin != "None":
         model_config.model.loras.add(lora_dir / origin)

--- a/gerd/frontends/generate.py
+++ b/gerd/frontends/generate.py
@@ -50,8 +50,6 @@ def load_model(model_name: str, origin: str) -> dict[str, Any]:
     model_config.model.name = model_name
     if origin != "None":
         model_config.model.loras.add(lora_dir / origin)
-    else:
-        model_config.model.loras.clear()
     Global.service = ChatService(model_config)
     return gr.update(interactive=True)
 

--- a/gerd/frontends/generate.py
+++ b/gerd/frontends/generate.py
@@ -50,6 +50,8 @@ def load_model(model_name: str, origin: str) -> dict[str, Any]:
     model_config.model.name = model_name
     if origin != "None":
         model_config.model.loras.add(lora_dir / origin)
+    else:
+        model_config.model.loras.clear()
     Global.service = ChatService(model_config)
     return gr.update(interactive=True)
 

--- a/gerd/frontends/training.py
+++ b/gerd/frontends/training.py
@@ -313,7 +313,7 @@ with demo:
                 maximum=1024,
                 step=1,
                 value=default_config.cutoff_len,
-                visible=select_training_mode == "Unstructured",
+                visible=select_training_mode.value == "Unstructured",
             )
             slider_overlap_len = gr.Slider(
                 label="Overlap Length",
@@ -321,7 +321,7 @@ with demo:
                 maximum=1024,
                 step=1,
                 value=default_config.overlap_len,
-                visible=select_training_mode == "Unstructured",
+                visible=select_training_mode.value == "Unstructured",
             )
             # slider_stop_at_loss = gr.Slider(
             #     label="Stop at Loss",
@@ -450,10 +450,10 @@ with demo:
         label=f"Glob pattern (should end with .{file_ext})",
         value=default_config.input_glob,
         placeholder=f"file://data/*.{file_ext}",
-        visible=select_data_origin == "Path",
+        visible=select_data_origin.value == "Path",
     )
     text_training_files = gr.Textbox(
-        label="Training files", visible=select_data_origin == "Path"
+        label="Training files", visible=select_data_origin.value == "Path"
     )
     text_glob_pattern.blur(
         get_file_list,

--- a/gerd/frontends/training.py
+++ b/gerd/frontends/training.py
@@ -133,7 +133,7 @@ def start_training(
         mode=training_mode,
         output_dir=default_config.output_dir.parent / lora_name,
         override_existing=override,
-        modules=LoraModules(**{mod: True for mod in modules}),
+        modules=LoraModules(default=False, **{mod: True for mod in modules}),
         flags=TrainingFlags(**{flag: True for flag in flags}),
         epochs=epochs,
         batch_size=batch_size,


### PR DESCRIPTION
Fixes severel issues with setting options via the frontends generate and train. Settings have not been correctly handled and are ignored in some cases. 

- **fix: use values of gradio elemtens for checks in frontend/training.py**
- **fix: check correctly for "None" lora in generate.py**
- **fix: reset list of loaded loras when chosing Non in generate.py**
- **fix: use correct projections for training in frontends/training.py**
