### PR TITLE
Fix-deepcopy-jinja

### DIFF
--- a/gerd/models/model.py
+++ b/gerd/models/model.py
@@ -1,5 +1,6 @@
 """Model configuration for supported model classes."""
 
+import logging
 import sys
 from pathlib import Path
 from string import Formatter
@@ -18,6 +19,9 @@ from pydantic import (
     SecretStr,
     computed_field,
 )
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.NullHandler())
 
 ChatRole = Literal["system", "user", "assistant"]
 """Currently supported chat roles."""
@@ -74,7 +78,12 @@ class PromptConfig(PromptConfigBase):
             memo = {}
 
         if id(self) in memo:
-            return memo[id(self)]
+            previous_copy = memo[id(self)]
+            if isinstance(previous_copy, PromptConfig):
+                return previous_copy
+            _LOGGER.warning(
+                "Previous copy of PromptConfig was not a PromptConfig object."
+            )
 
         copied_obj = PromptConfig.model_validate_json(self.model_dump_json())
         memo[id(self)] = copied_obj

--- a/gerd/models/model.py
+++ b/gerd/models/model.py
@@ -57,6 +57,21 @@ class PromptConfig(PromptConfigBase):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    # Jinja2 template is not deepcopyable:
+    # https://github.com/pallets/jinja/issues/758
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> "PromptConfig":
+        """Deep copy the prompt configuration.
+
+        We need to copy the PromptConfig object to avoid issues with the jinja2
+        template as it is not deepcopyable. We use the model_dump_json method to
+        serialize the object to JSON and then deserialize it back to a PromptConfig.
+        Parameters:
+            memo: The memo dictionary for the deepcopy
+        Returns:
+            A deep copy of the prompt configuration
+        """
+        return PromptConfig.model_validate_json(self.model_dump_json())
+
     def as_base(self) -> PromptConfigBase:
         """Returns parameter of the prompt configurations.
 

--- a/gerd/models/model.py
+++ b/gerd/models/model.py
@@ -70,7 +70,15 @@ class PromptConfig(PromptConfigBase):
         Returns:
             A deep copy of the prompt configuration
         """
-        return PromptConfig.model_validate_json(self.model_dump_json())
+        if memo is None:
+            memo = {}
+
+        if id(self) in memo:
+            return memo[id(self)]
+
+        copied_obj = PromptConfig.model_validate_json(self.model_dump_json())
+        memo[id(self)] = copied_obj
+        return copied_obj
 
     def as_base(self) -> PromptConfigBase:
         """Returns parameter of the prompt configurations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gerd"
-version = "0.7.8"
+version = "0.7.9"
 description = "Add your description here"
 readme = "docs/README.md"
 requires-python = ">=3.10, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ http = [
 
 [[package]]
 name = "gerd"
-version = "0.7.8"
+version = "0.7.9"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },


### PR DESCRIPTION
Jinja templates cannot be deepcopied. Workaround is to choose the serialization root